### PR TITLE
Remove artificial tracked state change delay

### DIFF
--- a/src/lib/steam/include/steam/steamappwatcher.h
+++ b/src/lib/steam/include/steam/steamappwatcher.h
@@ -43,6 +43,5 @@ private:
 
     enums::AppState m_current_state{enums::AppState::Stopped};
     QTimer          m_check_timer;
-    uint            m_delay_counter{0};
 };
 }  // namespace steam

--- a/src/lib/steam/steamappwatcher.cpp
+++ b/src/lib/steam/steamappwatcher.cpp
@@ -133,17 +133,10 @@ void SteamAppWatcher::slotCheckState()
 
     if (new_state != m_current_state)
     {
-        if (new_state == enums::AppState::Stopped && m_delay_counter < 5)
-        {
-            ++m_delay_counter;
-            return;
-        }
-
         qCInfo(lc::steam) << "[TRACKING] New app state for AppID" << m_app_id.getId()
                           << "detected:" << enums::qEnumToString(m_current_state) << "->"
                           << enums::qEnumToString(new_state);
         m_current_state = new_state;
-        m_delay_counter = 0;
     }
 }
 


### PR DESCRIPTION
I did a bit of research, and it appears the `Running -> Stopped -> Running` issue does not occur on Linux.

On Windows: When a game is launched via a `link2ea://` URL instead of a direct `.exe`, a new EA Launcher process is created outside of Steam. Game PID is tracked only after the game starts, because the game connects steam via steamapi.dll.

On Linux: The EA Launcher runs inside the Wine prefix, so its PID is tracked as part of the game process.

Tested this changes with several launcher-based games: Star Wars: Battlefront, GTA: Vice City Definitive Edition, and Watch Dogs 2.

[moondeckbuddy.log](https://github.com/user-attachments/files/28881776/moondeckbuddy.log)
